### PR TITLE
Using `python` as `python3.5`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
                 --name $DOCKER_CONTAINER_NAME_CNTK_TSNDT \
                 --restart unless-stopped \
                 -p $SNETD_PORT:$SNETD_PORT \
-                -di $DOCKER_IMAGE_NAME_CNTK_TSNDT sh -c "git pull;python3 $SERVICE_RUN_SCRIPT"
+                -di $DOCKER_IMAGE_NAME_CNTK_TSNDT sh -c "git pull;python $SERVICE_RUN_SCRIPT"
             EOF
       - run:
           name: Remove Old Docker Container
@@ -33,7 +33,7 @@ jobs:
           name: Test local
           command: |
             ssh -o "StrictHostKeyChecking no" $SSH_USER@$SSH_HOST << EOF
-              nvidia-docker exec -i $DOCKER_CONTAINER_NAME_CNTK_TSNDT python3 $SERVICE_TEST_SCRIPT auto
+              nvidia-docker exec -i $DOCKER_CONTAINER_NAME_CNTK_TSNDT python $SERVICE_TEST_SCRIPT auto
             EOF
   deploy-cntk-lstm-forecast:
     docker:
@@ -56,7 +56,7 @@ jobs:
                 --name $DOCKER_CONTAINER_NAME_CNTK_TSF \
                 --restart unless-stopped \
                 -p $SNETD_PORT:$SNETD_PORT \
-                -di $DOCKER_IMAGE_NAME_CNTK_TSF sh -c "git pull;python3 $SERVICE_RUN_SCRIPT"
+                -di $DOCKER_IMAGE_NAME_CNTK_TSF sh -c "git pull;python $SERVICE_RUN_SCRIPT"
             EOF
       - run:
           name: Remove Old Docker Container
@@ -68,7 +68,7 @@ jobs:
           name: Test local
           command: |
             ssh -o "StrictHostKeyChecking no" $SSH_USER@$SSH_HOST << EOF
-              nvidia-docker exec -i $DOCKER_CONTAINER_NAME_CNTK_TSF python3 $SERVICE_TEST_SCRIPT auto
+              nvidia-docker exec -i $DOCKER_CONTAINER_NAME_CNTK_TSF python $SERVICE_TEST_SCRIPT auto
             EOF
 
 workflows:

--- a/finance/cntk-next-day-trend/Dockerfile
+++ b/finance/cntk-next-day-trend/Dockerfile
@@ -80,7 +80,7 @@ RUN cd ${FINANCE_FOLDER}/${SERVICE_NAME} && \
                 }'" > ${SNETD_CONFIG}
 
 RUN cd ${FINANCE_FOLDER}/${SERVICE_NAME} && \
-    pip3 install -r requirements.txt && \
+    pip install -r requirements.txt && \
     sh buildproto.sh
 
 WORKDIR ${FINANCE_FOLDER}/${SERVICE_NAME}

--- a/finance/cntk-next-day-trend/buildproto.sh
+++ b/finance/cntk-next-day-trend/buildproto.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-python3.6 -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. service/service_spec/next_day_trend.proto
+python3 -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. service/service_spec/next_day_trend.proto

--- a/finance/cntk-next-day-trend/buildproto.sh
+++ b/finance/cntk-next-day-trend/buildproto.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-python3 -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. service/service_spec/next_day_trend.proto
+python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. service/service_spec/next_day_trend.proto

--- a/generic/cntk-lstm-forecast/Dockerfile
+++ b/generic/cntk-lstm-forecast/Dockerfile
@@ -80,7 +80,7 @@ RUN cd ${GENERIC_FOLDER}/${SERVICE_NAME} && \
                 }'" > ${SNETD_CONFIG}
 
 RUN cd ${GENERIC_FOLDER}/${SERVICE_NAME} && \
-    pip3 install -r requirements.txt && \
+    pip install -r requirements.txt && \
     sh buildproto.sh
 
 WORKDIR ${GENERIC_FOLDER}/${SERVICE_NAME}

--- a/generic/cntk-lstm-forecast/buildproto.sh
+++ b/generic/cntk-lstm-forecast/buildproto.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-python3 -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. service/service_spec/time_series_forecast.proto
+python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. service/service_spec/time_series_forecast.proto

--- a/generic/cntk-lstm-forecast/buildproto.sh
+++ b/generic/cntk-lstm-forecast/buildproto.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-python3.6 -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. service/service_spec/time_series_forecast.proto
+python3 -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. service/service_spec/time_series_forecast.proto


### PR DESCRIPTION
To avoid conflict with `python3.6` (for `snet-cli`).